### PR TITLE
Update security reporting link in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,4 +4,4 @@ If you find a significant vulnerability, or evidence of one,
 please report it privately.
 
 We prefer that you use the [GitHub mechanism for privately reporting a vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability). Under the
-[main repository's security tab](https://github.com/ossf/scorecard-action/security), click "Report a vulnerability" to open the advisory form.
+[main repository's security tab](https://github.com/daniecas/azure-devops-mermaid-viewer/security), click "Report a vulnerability" to open the advisory form.


### PR DESCRIPTION
Fixed security reporting link in SECURITY.md

And could you please enable it? It's a one-click toggle under:

**Settings → Security → Private vulnerability reporting → Enable**

So It will fix Open-SSF Issue.

This kind of button expected after above setting changed.

<img width="1003" height="205" alt="image" src="https://github.com/user-attachments/assets/9db9bdde-f051-424e-b97c-0dab47be1ae8" />
